### PR TITLE
Refacto/standardize fields

### DIFF
--- a/app/api/v1/workshop_views.py
+++ b/app/api/v1/workshop_views.py
@@ -5,10 +5,12 @@ from flask_jwt_extended import jwt_required
 from app.common.access_level import requires_access_level
 from app.models.user_model import Roles
 from app.services.workshop_services import (
+    add_participant,
     create_workshop,
     delete_workshop,
     get_workshop,
     get_workshops,
+    remove_participant,
 )
 
 
@@ -38,4 +40,23 @@ class WorkshopView(MethodView):
     @requires_access_level(Roles.COACH)
     def get(self, workshop_id):
         response, code = get_workshop(workshop_id=workshop_id)
+        return make_response(jsonify(response), code)
+
+
+class WorkshopParticipantView(MethodView):
+    @jwt_required
+    @requires_access_level(Roles.COACH)
+    def delete(self, workshop_id, participant_id):
+        response, code = remove_participant(
+            workshop_id=workshop_id, participant_id=participant_id
+        )
+        return make_response(jsonify(response), code)
+
+
+class WorkshopParticipantListView(MethodView):
+    @jwt_required
+    @requires_access_level(Roles.COACH)
+    def post(self, workshop_id):
+        data = request.data
+        response, code = add_participant(workshop_id=workshop_id, user_data=data)
         return make_response(jsonify(response), code)

--- a/app/config.py
+++ b/app/config.py
@@ -8,8 +8,7 @@ class Config:
     JWT_SECRET_KEY = SECRET_KEY
     DEBUG = False
     PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME", "")
-    # Flask-resful
-    JSONIFY_PRETTYPRINT_REGULAR = True
+    JSON_SORT_KEYS = False
 
     # Flask-JWT-Extended
     JWT_BLACKLIST_ENABLED = True

--- a/app/models/action_card_model.py
+++ b/app/models/action_card_model.py
@@ -20,8 +20,8 @@ class ActionCardModel(db.Document):
     meta = {"collection": "actionCards"}
 
     actionCardId = db.StringField(primary_key=True, default=generate_id)
-    number = db.IntField(required=True, min_value=0)
-    title = db.StringField(required=True)
+    cardNumber = db.IntField(required=True, min_value=0)
+    name = db.StringField(required=True)
     category = db.StringField(required=True)
     type = db.StringField(required=True)
     key = db.StringField(required=True)
@@ -40,8 +40,7 @@ class ActionCardBatchModel(db.Document):
 
     actionCardBatchId = db.StringField(primary_key=True, default=generate_id)
     coachId = db.StringField()
-    number = db.IntField(required=True, min_value=0)
-    title = db.StringField(required=True)
+    name = db.StringField(required=True)
     actionCardIds = db.ListField(db.StringField(), required=True)
     type = db.StringField(required=True)
     default = db.BooleanField()

--- a/app/models/participant_model.py
+++ b/app/models/participant_model.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from app.models import db
+
+
+class ParticipantStatus(Enum):
+    CREATED = "created"
+    EXISTING = "existing"
+    FORMSENT = "formsent"
+    TOCHECK = "tocheck"
+    READY = "ready"
+
+
+class ParticipantModel(db.EmbeddedDocument):
+    from app.models.user_model import UserModel
+
+    user = db.ReferenceField(UserModel)
+    status = db.StringField(max_length=32)

--- a/app/models/user_model.py
+++ b/app/models/user_model.py
@@ -56,6 +56,7 @@ class UserModel(db.Document):
     role = db.ListField(db.StringField(max_length=32), required=True)
     createdAt = db.DateTimeField(default=datetime.datetime.utcnow)
     updatedAt = db.DateTimeField(default=datetime.datetime.utcnow)
+    workshopParticipations = db.ListField(db.StringField())
 
     def __str__(self):
         return f"User {self.userId} - {self.firstName} {self.lastName}"

--- a/app/models/workshop_model.py
+++ b/app/models/workshop_model.py
@@ -29,7 +29,7 @@ class WorkshopModel(db.Document):
     city = db.StringField(max_length=128, min_length=1)
     address = db.StringField(max_length=512)
     participants = db.ListField(db.EmbeddedDocumentField(ParticipantModel), default=[])
-    model = db.ReferenceField(Model)
+    model = db.ReferenceField(Model, db_field="modelId")
 
     def __repr__(self):
         return (

--- a/app/models/workshop_model.py
+++ b/app/models/workshop_model.py
@@ -5,6 +5,7 @@ import datetime
 from app.common.uuid_generator import generate_id
 from app.models import db
 from app.models.model_model import Model
+from app.models.participant_model import ParticipantModel
 
 
 class WorkshopModel(db.Document):
@@ -27,12 +28,14 @@ class WorkshopModel(db.Document):
     eventUrl = db.StringField(default="caplc.com")
     city = db.StringField(max_length=128, min_length=1)
     address = db.StringField(max_length=512)
+    participants = db.ListField(db.EmbeddedDocumentField(ParticipantModel), default=[])
     model = db.ReferenceField(Model)
 
     def __repr__(self):
         return (
             f"<Workshop {self.workshopId} | {self.name} "
-            f"- animated by {self.coachId} at {self.city} on {self.startAt}>"
+            f"- animated by {self.coachId} at {self.city} on {self.startAt} "
+            f"- with {len(self.participants)} participants>"
         )
 
     @classmethod

--- a/app/models/workshop_model.py
+++ b/app/models/workshop_model.py
@@ -16,7 +16,7 @@ class WorkshopModel(db.Document):
     meta = {"collection": "workshops"}
 
     workshopId = db.StringField(primary_key=True, default=generate_id)
-    title = db.StringField(
+    name = db.StringField(
         required=True, max_length=128, min_length=1, default="Atelier CAPLC"
     )
     createdAt = db.DateTimeField(default=datetime.datetime.utcnow)
@@ -31,7 +31,7 @@ class WorkshopModel(db.Document):
 
     def __repr__(self):
         return (
-            f"<Workshop {self.workshopId} | {self.title} "
+            f"<Workshop {self.workshopId} | {self.name} "
             f"- animated by {self.coachId} at {self.city} on {self.startAt}>"
         )
 

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,6 +4,9 @@ from app.common.errors import EmptyBodyError, InvalidDataError
 
 
 class CustomSchema(Schema):
+    class Meta:
+        ordered = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/app/schemas/action_card_schemas.py
+++ b/app/schemas/action_card_schemas.py
@@ -5,9 +5,9 @@ from app.schemas import CustomSchema
 
 
 class ActionCardSchema(CustomSchema):
-    actionCardId = fields.Str(dump_only=True)
-    number = fields.Integer(strict=True, validate=validate.Range(min=1))
-    title = fields.Str(validate=validate.Length(min=1, max=256))
+    id = fields.Str(dump_only=True)
+    cardNumber = fields.Integer(strict=True, validate=validate.Range(min=1))
+    name = fields.Str(validate=validate.Length(min=1, max=256))
     category = fields.Str(validate=validate.Length(min=1, max=64))
     type = fields.Str(validate=validate.Length(min=1, max=64))
     key = fields.Str(validate=validate.Length(min=1, max=128))
@@ -16,9 +16,8 @@ class ActionCardSchema(CustomSchema):
 
 
 class ActionCardBatchSchema(CustomSchema):
-    actionCardBatchId = fields.Str()
-    number = fields.Integer(strict=True, validate=validate.Range(min=1))
-    title = fields.Str()
+    id = fields.Str()
+    name = fields.Str()
     actionCardIds = fields.List(fields.Str(), validate=validate.Length(min=1))
     type = fields.Str(
         validate=validate.OneOf(
@@ -38,7 +37,7 @@ class ActionCardBatchSchema(CustomSchema):
                 if action_card_id not in existing_action_cards:
                     raise ValidationError(
                         "actionCardId {} does not exist. (Batch {})".format(
-                            action_card_id, d["title"]
+                            action_card_id, d["name"]
                         ),
                         "actionCardIds",
                     )
@@ -56,7 +55,7 @@ class ActionCardBatchSchema(CustomSchema):
             ):
                 raise ValidationError(
                     "Action cards within the same batch must be of the same type. "
-                    "(Batch {})".format(d["title"]),
+                    "(Batch {})".format(d["name"]),
                     "actionCardIds",
                 )
 

--- a/app/schemas/coach_schemas.py
+++ b/app/schemas/coach_schemas.py
@@ -6,7 +6,7 @@ from app.schemas import CustomSchema
 
 
 class CoachSchema(CustomSchema):
-    userId = fields.Str(dump_only=True)
+    id = fields.Str(dump_only=True)
     firstName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
     lastName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
     email = fields.Email(required=True, max=256)

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -16,3 +16,10 @@ class NewPasswordSchema(CustomSchema):
     password = fields.Str(
         required=True, validate=validate.Length(min=8), load_only=True
     )
+
+
+class UserSchema(CustomSchema):
+    userId = fields.Str(dump_only=True)
+    firstName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
+    lastName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
+    email = fields.Email(required=True, max=256)

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -19,7 +19,7 @@ class NewPasswordSchema(CustomSchema):
 
 
 class UserSchema(CustomSchema):
-    userId = fields.Str(dump_only=True)
+    id = fields.Str(dump_only=True)
     firstName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
     lastName = fields.Str(required=True, validate=validate.Length(min=1, max=64))
     email = fields.Email(required=True, max=256)

--- a/app/schemas/workshop_schemas.py
+++ b/app/schemas/workshop_schemas.py
@@ -6,8 +6,8 @@ from app.schemas.action_card_schemas import ActionCardBatchSchema, ActionCardSch
 
 
 class WorkshopSchema(CustomSchema):
-    workshopId = fields.Str(dump_only=True)
-    title = fields.Str(required=True, validate=validate.Length(min=1, max=128))
+    id = fields.Str(dump_only=True)
+    name = fields.Str(required=True, validate=validate.Length(min=1, max=128))
     startAt = fields.AwareDateTime(required=True)
     creatorId = fields.Str(dump_only=True)
     coachId = fields.Str(required=True, validate=validate.Length(min=1))
@@ -43,7 +43,7 @@ class WorkshopDetailSchema(WorkshopSchema):
     @post_dump
     def sort_model_action_cards(self, data, **kwargs):
         action_cards = data["model"]["actionCards"]
-        action_cards = sorted(action_cards, key=lambda x: x["number"])
+        action_cards = sorted(action_cards, key=lambda x: x["cardNumber"])
 
         data["model"]["actionCards"] = action_cards
         return data
@@ -51,7 +51,7 @@ class WorkshopDetailSchema(WorkshopSchema):
     @post_dump
     def sort_model_action_card_batches(self, data, **kwargs):
         action_card_batches = data["model"]["actionCardBatches"]
-        action_card_batches = sorted(action_card_batches, key=lambda x: x["title"])
+        action_card_batches = sorted(action_card_batches, key=lambda x: x["name"])
 
         data["model"]["actionCardBatches"] = action_card_batches
         return data

--- a/app/schemas/workshop_schemas.py
+++ b/app/schemas/workshop_schemas.py
@@ -3,6 +3,7 @@ from marshmallow import ValidationError, fields, post_dump, post_load, validate
 from app.models.coach_model import CoachModel
 from app.schemas import CustomSchema
 from app.schemas.action_card_schemas import ActionCardBatchSchema, ActionCardSchema
+from app.schemas.user_schemas import UserSchema
 
 
 class WorkshopSchema(CustomSchema):
@@ -27,6 +28,17 @@ class WorkshopSchema(CustomSchema):
         return data
 
 
+class WorkshopParticipantSchema(CustomSchema):
+    status = fields.Str()
+    user = fields.Nested(UserSchema)
+
+    @post_dump
+    def flatten_participant(self, data, **kwargs):
+        data = {**data, **data["user"]}
+        del data["user"]
+        return data
+
+
 class WorkshopModelSchema(CustomSchema):
     id = fields.Str()
     footprintStructure = fields.Dict()
@@ -37,8 +49,8 @@ class WorkshopModelSchema(CustomSchema):
 
 
 class WorkshopDetailSchema(WorkshopSchema):
+    participants = fields.List(fields.Nested(WorkshopParticipantSchema))
     model = fields.Nested(WorkshopModelSchema)
-    # participants = fields.List(fields.Nested(WorkshopParticipantSchema))
 
     @post_dump
     def sort_model_action_cards(self, data, **kwargs):

--- a/app/services/coach_services.py
+++ b/app/services/coach_services.py
@@ -61,8 +61,7 @@ def create_coach(data: bytes) -> (dict, int):
     for default_action_card_batch in default_action_card_batches:
         ActionCardBatchModel(
             coachId=user.id,
-            number=default_action_card_batch.number,
-            title=default_action_card_batch.title,
+            name=default_action_card_batch.name,
             actionCardIds=default_action_card_batch.actionCardIds,
             type=default_action_card_batch.type,
         ).save()

--- a/app/services/workshop_services.py
+++ b/app/services/workshop_services.py
@@ -95,7 +95,7 @@ def add_participant(workshop_id, user_data) -> (dict, int):
         workshop.participants.append(participant)
     user.save()
     workshop.save()
-    return get_workshop(workshop_id)
+    return UserSchema().dump(user), 200
 
 
 def remove_participant(workshop_id, participant_id) -> (dict, int):
@@ -116,4 +116,4 @@ def remove_participant(workshop_id, participant_id) -> (dict, int):
     user.workshopParticipations = updated_workshop
     workshop.save()
     user.save()
-    return get_workshop(workshop_id)
+    return None, 204

--- a/app/services/workshop_services.py
+++ b/app/services/workshop_services.py
@@ -3,7 +3,10 @@ from flask_jwt_extended import get_jwt_identity
 from app.common.errors import EntityNotFoundError
 from app.models.action_card_model import ActionCardBatchModel, ActionCardModel
 from app.models.model_model import Model
+from app.models.participant_model import ParticipantModel
+from app.models.user_model import UserModel
 from app.models.workshop_model import WorkshopModel
+from app.schemas.user_schemas import UserSchema
 from app.schemas.workshop_schemas import WorkshopDetailSchema, WorkshopSchema
 
 
@@ -62,3 +65,55 @@ def delete_workshop(workshop_id: str) -> (dict, int):
     workshop.delete()
 
     return {}, 204
+
+
+def add_participant(workshop_id, user_data) -> (dict, int):
+    workshop = WorkshopModel.find_by_id(workshop_id=workshop_id)
+    user_data, err_msg, err_code = UserSchema().loads_or_400(user_data)
+    if err_msg:
+        return err_msg, err_code
+    # Check if given workshop_id exists in DB
+    if workshop is None:
+        raise EntityNotFoundError
+    user = UserModel.find_by_email(user_data.get("email"))
+    participant = None
+    if user is None:
+        user = UserModel(
+            email=user_data.get("email"),
+            firstName=user_data.get("firstName"),
+            lastName=user_data.get("lastName"),
+            role=["participant"],
+        )
+        user.save()
+        status = "created"
+    else:
+        status = "existing"
+    user.reload()
+    participant = ParticipantModel(user=user.userId, status=status)
+    if workshop_id not in user.workshopParticipations:
+        user.workshopParticipations.append(workshop_id)
+        workshop.participants.append(participant)
+    user.save()
+    workshop.save()
+    return get_workshop(workshop_id)
+
+
+def remove_participant(workshop_id, participant_id) -> (dict, int):
+    workshop = WorkshopModel.find_by_id(workshop_id=workshop_id)
+    user = UserModel.find_by_id(participant_id)
+    # Check if given workshop_id exists in DB
+    if workshop is None or user is None:
+        raise EntityNotFoundError
+    updated_participants = []
+    for participant in workshop.participants:
+        if participant.user.userId != participant_id:
+            updated_participants.append(participant)
+    workshop.participants = updated_participants
+    updated_workshop = []
+    for registered in user.workshopParticipations:
+        if registered != workshop_id:
+            updated_workshop.append(registered)
+    user.workshopParticipations = updated_workshop
+    workshop.save()
+    user.save()
+    return get_workshop(workshop_id)

--- a/app/urls.py
+++ b/app/urls.py
@@ -8,7 +8,12 @@ from app.api.v1.user_views import (
     ResetPasswordView,
     UserMeView,
 )
-from app.api.v1.workshop_views import WorkshopListView, WorkshopView
+from app.api.v1.workshop_views import (
+    WorkshopListView,
+    WorkshopParticipantListView,
+    WorkshopParticipantView,
+    WorkshopView,
+)
 
 urlpatterns = [
     dict(view=PingView, url="/api/ping", endpoint="ping", methods=["GET"]),
@@ -62,5 +67,18 @@ urlpatterns = [
         url="/api/v1/workshops/<string:workshop_id>",
         endpoint="workshop",
         methods=["DELETE", "GET"],
+    ),
+    dict(
+        view=WorkshopParticipantListView,
+        url="/api/v1/workshops/<string:workshop_id>/participants",
+        endpoint="workshop-participant-list",
+        methods=["POST"],
+    ),
+    dict(
+        view=WorkshopParticipantView,
+        url="/api/v1/workshops/<string:workshop_id>/"
+        "participants/<string:participant_id>",
+        endpoint="workshop-participant",
+        methods=["DELETE"],
     ),
 ]

--- a/ressources/csv/action_card_batches.csv.example
+++ b/ressources/csv/action_card_batches.csv.example
@@ -1,3 +1,3 @@
-actionCardBatchId,number,title,type,actionCardIds,default
-1,1,action_card_batch_title_1,individual,"[""1"", ""2""]",true
-2,2,action_card_batch_title_2,collective,"[""3""]",true
+actionCardBatchId,name,type,actionCardIds,default
+1,action_card_batch_name_1,individual,"[""1"", ""2""]",true
+2,action_card_batch_name_2,collective,"[""3""]",true

--- a/ressources/csv/action_cards.csv.example
+++ b/ressources/csv/action_cards.csv.example
@@ -1,4 +1,4 @@
-actionCardId,number,title,category,type,key,sector,cost
-1,1,action_card_title_1,eco-friendly action,individual,action_card_key_1,action_card_sector_1,1
-2,2,action_card_title_2,awareness,individual,action_card_key_2,action_card_sector_2,2
-3,3,action_card_title_3,system,collective,action_card_key_3,action_card_sector_3,3
+actionCardId,cardNumber,name,category,type,key,sector,cost
+1,1,action_card_name_1,eco-friendly action,individual,action_card_key_1,action_card_sector_1,1
+2,2,action_card_name_2,awareness,individual,action_card_key_2,action_card_sector_2,2
+3,3,action_card_name_3,system,collective,action_card_key_3,action_card_sector_3,3

--- a/tests/test_action_cards.py
+++ b/tests/test_action_cards.py
@@ -16,8 +16,8 @@ from app.models.user_model import Roles
 @pytest.fixture(scope="class")
 def create_some_action_cards(db, request):
     action_card1 = ActionCardModel(
-        number=1,
-        title="action_card_title_1",
+        cardNumber=1,
+        name="action_card_name_1",
         category=ActionCardCategory.AWARENESS.value,
         type=ActionCardType.INDIVIDUAL.value,
         key="action_card_key_1",
@@ -26,8 +26,8 @@ def create_some_action_cards(db, request):
     )
 
     action_card2 = ActionCardModel(
-        number=2,
-        title="action_card_title_2",
+        cardNumber=2,
+        name="action_card_name_2",
         category=ActionCardCategory.ECOFRIENDLY_ACTION.value,
         type=ActionCardType.INDIVIDUAL.value,
         key="action_card_key_2",
@@ -35,8 +35,8 @@ def create_some_action_cards(db, request):
         cost=2,
     )
     action_card3 = ActionCardModel(
-        number=3,
-        title="action_card_title_3",
+        cardNumber=3,
+        name="action_card_name_3",
         category=ActionCardCategory.SYSTEM.value,
         type=ActionCardType.COLLECTIVE.value,
         key="action_card_key_3",
@@ -64,32 +64,28 @@ def create_some_action_card_batches(init_coach, request):
     # Coach's batch
     action_card_batch1 = ActionCardBatchModel(
         coachId=init_coach.id,
-        number=1,
-        title="action_card_batch_title_1",
+        name="action_card_batch_name_1",
         type=ActionCardType.INDIVIDUAL.value,
         actionCardIds=["1", "2"],
     )
 
     action_card_batch2 = ActionCardBatchModel(
         coachId=init_coach.id,
-        number=2,
-        title="action_card_batch_title_2",
+        name="action_card_batch_name_2",
         type=ActionCardType.COLLECTIVE.value,
         actionCardIds=["1", "3"],
     )
     # Default batches
     action_card_batch3 = ActionCardBatchModel(
         default=True,
-        number=3,
-        title="action_card_batch_title_3",
+        name="action_card_batch_name_3",
         type=ActionCardType.INDIVIDUAL.value,
         actionCardIds=["1", "2"],
     )
 
     action_card_batch4 = ActionCardBatchModel(
         default=True,
-        number=4,
-        title="action_card_batch_title_4",
+        name="action_card_batch_name_4",
         type=ActionCardType.COLLECTIVE.value,
         actionCardIds=["1", "3"],
     )
@@ -124,9 +120,9 @@ class TestActionCardsRessourcesWithExistingData:
         response_data, status_code = json.loads(response.data), response.status_code
 
         expected_first_result = {
-            "actionCardId": self.action_cards[0].actionCardId,
-            "number": self.action_cards[0].number,
-            "title": self.action_cards[0].title,
+            "id": self.action_cards[0].actionCardId,
+            "cardNumber": self.action_cards[0].cardNumber,
+            "name": self.action_cards[0].name,
             "category": self.action_cards[0].category,
             "type": self.action_cards[0].type,
             "key": self.action_cards[0].key,
@@ -150,9 +146,8 @@ class TestActionCardsRessourcesWithExistingData:
         response_data, status_code = json.loads(response.data), response.status_code
         action_card_batches = create_some_action_card_batches
         expected_first_result = {
-            "actionCardBatchId": action_card_batches[0].actionCardBatchId,
-            "number": action_card_batches[0].number,
-            "title": action_card_batches[0].title,
+            "id": action_card_batches[0].actionCardBatchId,
+            "name": action_card_batches[0].name,
             "type": action_card_batches[0].type,
             "actionCardIds": action_card_batches[0].actionCardIds,
         }
@@ -173,17 +168,13 @@ class TestActionCardsRessourcesWithExistingData:
 
         data = [
             {
-                "number": 1,
-                "title": "action_card_batch_title_1",
+                "name": "action_card_batch_name_1",
                 "type": ActionCardType.INDIVIDUAL.value,
                 "actionCardIds": [action_card1.id, action_card2.id],
             },
             {
-                "actionCardBatchId": create_some_action_card_batches[
-                    0
-                ].actionCardBatchId,
-                "number": 2,
-                "title": "action_card_batch_title_2_bis",
+                "id": create_some_action_card_batches[0].actionCardBatchId,
+                "name": "action_card_batch_name_2_bis",
                 "type": ActionCardType.COLLECTIVE.value,
                 "actionCardIds": [action_card3.id],
             },
@@ -197,7 +188,7 @@ class TestActionCardsRessourcesWithExistingData:
         response_data, status_code = json.loads(response.data), response.status_code
 
         assert status_code == 200
-        assert "actionCardBatchId" in response_data[0]
+        assert "id" in response_data[0]
         assert (
             len(
                 ActionCardBatchModel.find_action_card_batches_by_coach(
@@ -215,14 +206,12 @@ class TestActionCardsRessourcesWithExistingData:
         incorrect_id = "incorrect_id"
         data = [
             {
-                "number": 1,
-                "title": "action_card_batch_title_1",
+                "name": "action_card_batch_name_1",
                 "type": ActionCardType.INDIVIDUAL.value,
                 "actionCardIds": [incorrect_id, action_card2.id],
             },
             {
-                "number": 2,
-                "title": "action_card_batch_title_2",
+                "name": "action_card_batch_name_2",
                 "type": ActionCardType.COLLECTIVE.value,
                 "actionCardIds": [action_card3.id],
             },
@@ -257,14 +246,12 @@ class TestActionCardsRessourcesWithExistingData:
         )
         data = [
             {
-                "number": 1,
-                "title": "action_card_batch_title_1",
+                "name": "action_card_batch_name_1",
                 "type": ActionCardType.INDIVIDUAL.value,
                 "actionCardIds": [action_card2.id],
             },
             {
-                "number": 2,
-                "title": "action_card_batch_title_2",
+                "name": "action_card_batch_name_2",
                 "type": ActionCardType.COLLECTIVE.value,
                 "actionCardIds": [action_card3.id],
             },
@@ -302,14 +289,12 @@ class TestActionCardsRessourcesWithExistingData:
         )
         data = [
             {
-                "number": 1,
-                "title": "action_card_batch_title_1",
+                "name": "action_card_batch_name_1",
                 "type": ActionCardType.INDIVIDUAL.value,
                 "actionCardIds": [action_card3.id, action_card2.id],
             },
             {
-                "number": 2,
-                "title": "action_card_batch_title_2",
+                "name": "action_card_batch_name_2",
                 "type": ActionCardType.COLLECTIVE.value,
                 "actionCardIds": [action_card1.id],
             },
@@ -352,13 +337,13 @@ class TestActionCardsRessourcesWithExistingData:
         response = client.post(
             "/api/v1/coaches", headers=headers, data=json.dumps(data)
         )
-        coach_id = json.loads(response.data)["userId"]
+        coach_id = json.loads(response.data)["id"]
 
         action_card_batches = ActionCardBatchModel.find_action_card_batches_by_coach(
             coach_id
         )
         assert len(action_card_batches) == 2
-        assert create_some_action_card_batches[2].title == action_card_batches[0].title
+        assert create_some_action_card_batches[2].name == action_card_batches[0].name
 
         def teardown():
             CoachModel.find_by_id(coach_id).delete()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,8 +73,8 @@ def test_importcsv_no_drop(cli_runner, db, request):
 
     # Inserting an action card beforehand
     action_card4 = ActionCardModel(
-        number=4,
-        title="action_card_title_4",
+        cardNumber=4,
+        name="action_card_name_4",
         category="action_card_category_4",
         type="action_card_type_4",
         key="action_card_key_4",
@@ -108,8 +108,8 @@ def test_importcsv_with_drop(cli_runner, db, request):
 
     # Inserting an action card beforehand
     action_card4 = ActionCardModel(
-        number=4,
-        title="action_card_title_4",
+        cardNumber=4,
+        name="action_card_name_4",
         category="action_card_category_4",
         type="action_card_type_4",
         key="action_card_key_4",

--- a/tests/test_workshops_basics.py
+++ b/tests/test_workshops_basics.py
@@ -19,7 +19,7 @@ def invalid_workshops_data(init_coach):
             coachId=init_coach.id,
         ),
         dict(  # Invalid date format
-            title="Atelier Data 4 Good",
+            name="Atelier Data 4 Good",
             startAt="Invalid date format",
             city="Paris",
             address="Avenue Champ Elysee",
@@ -27,7 +27,7 @@ def invalid_workshops_data(init_coach):
             coachId=init_coach.id,
         ),
         dict(  # inexisting coach id
-            title="Atelier Data 4 Good",
+            name="Atelier Data 4 Good",
             startAt="2020-01-01T01:01:01+01:00",
             city="Paris",
             address="Avenue Champ Elysee",
@@ -41,7 +41,7 @@ def invalid_workshops_data(init_coach):
 @pytest.fixture(scope="function")
 def create_some_workshops(db, request, init_coach):
     workshop1 = WorkshopModel(
-        title="workshop_title_1",
+        name="workshop_name_1",
         startAt=datetime(2020, 1, 1, 1, 1, 1),
         city="city_1",
         address="address1",
@@ -51,7 +51,7 @@ def create_some_workshops(db, request, init_coach):
         model=None,
     )
     workshop2 = WorkshopModel(
-        title="workshop_title_2",
+        name="workshop_name_2",
         startAt=datetime(2020, 2, 2, 2, 2, 2),
         city="city_2",
         address="address2",
@@ -82,24 +82,24 @@ def test_get_workshops(client, auth, init_admin, create_some_workshops):
 
     expected_output = [
         dict(
-            title=workshop1.title,
+            name=workshop1.name,
             startAt=workshop1.startAt.isoformat(),
             city=workshop1.city,
             address=workshop1.address,
             eventUrl=workshop1.eventUrl,
             coachId=workshop1.coachId,
             creatorId=workshop1.creatorId,
-            workshopId=workshop1.id,
+            id=workshop1.id,
         ),
         dict(
-            title=workshop2.title,
+            name=workshop2.name,
             startAt=workshop2.startAt.isoformat(),
             city=workshop2.city,
             address=workshop2.address,
             eventUrl=workshop2.eventUrl,
             coachId=workshop2.coachId,
             creatorId=workshop2.creatorId,
-            workshopId=workshop2.id,
+            id=workshop2.id,
         ),
     ]
     assert status_code == 200
@@ -108,7 +108,7 @@ def test_get_workshops(client, auth, init_admin, create_some_workshops):
 
 def test_delete_workshop(client, auth, init_admin, request):
     workshop = WorkshopModel(
-        title="Atelier Data 4 Good",
+        name="Atelier Data 4 Good",
         startAt=datetime(2020, 4, 4, 1, 1, 1),
         city="Paris",
         address="Avenue Champ Elysee",
@@ -159,7 +159,7 @@ def test_post_workshop_success(client, auth, init_admin, init_coach, request):
     model.save()
 
     data = dict(
-        title="Atelier Data 4 Good",
+        name="Atelier Data 4 Good",
         startAt="2020-01-01T01:01:01+01:00",
         city="Paris",
         address="Avenue Champ Elysee",
@@ -175,7 +175,7 @@ def test_post_workshop_success(client, auth, init_admin, init_coach, request):
     assert len(WorkshopModel.objects()) == 1
 
     def teardown():
-        workshop = WorkshopModel.find_by_id(response_data["workshopId"])
+        workshop = WorkshopModel.find_by_id(response_data["id"])
         workshop.delete()
         model.delete()
 
@@ -209,7 +209,7 @@ def test_post_workshops_with_empty_body(client, auth, init_admin):
 
 def test_post_workshops_but_no_model_in_db(client, auth, init_admin):
     data = dict(
-        title="Atelier Data 4 Good",
+        name="Atelier Data 4 Good",
         startAt="2020-01-01T01:01:01+01:00",
         city="Paris",
         address="Avenue Champ Elysee",
@@ -241,7 +241,7 @@ def test_last_created_model_at_workshop_creation(client, auth, init_admin, reque
     model2.save()
 
     data = dict(
-        title="Atelier Data 4 Good",
+        name="Atelier Data 4 Good",
         startAt="2020-01-01T01:01:01+01:00",
         city="Paris",
         address="Avenue Champ Elysee",
@@ -252,7 +252,7 @@ def test_last_created_model_at_workshop_creation(client, auth, init_admin, reque
     headers = auth.login(email="admin@test.com")
     response = client.post("/api/v1/workshops", headers=headers, data=json.dumps(data))
 
-    workshop = WorkshopModel.find_by_id(json.loads(response.data)["workshopId"])
+    workshop = WorkshopModel.find_by_id(json.loads(response.data)["id"])
 
     assert workshop.model.id == model2.id
 

--- a/tests/test_workshops_details.py
+++ b/tests/test_workshops_details.py
@@ -54,8 +54,8 @@ def setup_data(init_coach, request):
     model.save()
 
     action_card1 = ActionCardModel(
-        number=1,
-        title="action_card_title_1",
+        cardNumber=1,
+        name="action_card_name_1",
         category=ActionCardCategory.AWARENESS.value,
         type=ActionCardType.INDIVIDUAL.value,
         key="action_card_key_1",
@@ -64,8 +64,8 @@ def setup_data(init_coach, request):
     )
 
     action_card2 = ActionCardModel(
-        number=2,
-        title="action_card_title_2",
+        cardNumber=2,
+        name="action_card_name_2",
         category=ActionCardCategory.ECOFRIENDLY_ACTION.value,
         type=ActionCardType.INDIVIDUAL.value,
         key="action_card_key_2",
@@ -73,8 +73,8 @@ def setup_data(init_coach, request):
         cost=2,
     )
     action_card3 = ActionCardModel(
-        number=3,
-        title="action_card_title_3",
+        cardNumber=3,
+        name="action_card_name_3",
         category=ActionCardCategory.SYSTEM.value,
         type=ActionCardType.COLLECTIVE.value,
         key="action_card_key_3",
@@ -89,16 +89,14 @@ def setup_data(init_coach, request):
 
     action_card_batch1 = ActionCardBatchModel(
         coachId=init_coach.id,
-        number=1,
-        title="action_card_batch_title_1",
+        name="action_card_batch_name_1",
         type=ActionCardType.INDIVIDUAL.value,
         actionCardIds=[action_card1.id, action_card2.id],
     )
 
     action_card_batch2 = ActionCardBatchModel(
         coachId=init_coach.id,
-        number=2,
-        title="action_card_batch_title_2",
+        name="action_card_batch_name_2",
         type=ActionCardType.COLLECTIVE.value,
         actionCardIds=[action_card3.id],
     )
@@ -108,7 +106,7 @@ def setup_data(init_coach, request):
     action_card_batches = [action_card_batch1, action_card_batch2]
 
     workshop = WorkshopModel(
-        title="workshop_title_1",
+        name="workshop_name_1",
         startAt=datetime(2020, 1, 1, 1, 1, 1),
         city="city_1",
         address="address1",
@@ -142,14 +140,14 @@ def test_get_workshop(client, auth, init_coach, setup_data):
     response_data, status_code = json.loads(response.data), response.status_code
 
     expected_output = {
-        "title": workshop.title,
+        "name": workshop.name,
         "startAt": workshop.startAt.isoformat(),
         "city": workshop.city,
         "address": workshop.address,
         "eventUrl": workshop.eventUrl,
         "coachId": workshop.coachId,
         "creatorId": workshop.creatorId,
-        "workshopId": workshop.id,
+        "id": workshop.id,
         "model": {
             "id": model.id,
             "globalCarbonVariables": model.globalCarbonVariables,
@@ -157,9 +155,9 @@ def test_get_workshop(client, auth, init_coach, setup_data):
             "footprintStructure": model.footprintStructure,
             "actionCards": [
                 {
-                    "actionCardId": action_card.actionCardId,
-                    "number": action_card.number,
-                    "title": action_card.title,
+                    "id": action_card.actionCardId,
+                    "cardNumber": action_card.cardNumber,
+                    "name": action_card.name,
                     "category": action_card.category,
                     "type": action_card.type,
                     "key": action_card.key,
@@ -170,9 +168,8 @@ def test_get_workshop(client, auth, init_coach, setup_data):
             ],
             "actionCardBatches": [
                 {
-                    "actionCardBatchId": action_card_batch.actionCardBatchId,
-                    "number": action_card_batch.number,
-                    "title": action_card_batch.title,
+                    "id": action_card_batch.actionCardBatchId,
+                    "name": action_card_batch.name,
                     "type": action_card_batch.type,
                     "actionCardIds": action_card_batch.actionCardIds,
                 }

--- a/tests/test_workshops_details.py
+++ b/tests/test_workshops_details.py
@@ -173,7 +173,7 @@ def test_get_workshop(client, auth, init_coach, setup_data):
                 "email": user.email,
                 "firstName": user.firstName,
                 "lastName": user.lastName,
-                "userId": user.userId,
+                "id": user.userId,
             }
         ],
         "model": {
@@ -243,5 +243,5 @@ def test_delete_participant_workshop(client, auth, init_coach, setup_data, reque
     status_code = response.status_code
 
     workshop.reload()
-    assert status_code == 200
+    assert status_code == 204
     assert len(workshop.participants) == 0

--- a/tests/test_workshops_details.py
+++ b/tests/test_workshops_details.py
@@ -10,6 +10,8 @@ from app.models.action_card_model import (
     ActionCardType,
 )
 from app.models.model_model import Model
+from app.models.participant_model import ParticipantModel
+from app.models.user_model import UserModel
 from app.models.workshop_model import WorkshopModel
 
 
@@ -105,6 +107,21 @@ def setup_data(init_coach, request):
 
     action_card_batches = [action_card_batch1, action_card_batch2]
 
+    user = UserModel(
+        email="schwarzy@gmail.com",
+        firstName="Arnold",
+        lastName="Schwarzy",
+        role=["participant"],
+    )
+    user.save()
+    user.reload()
+    user_to_add = {
+        "email": "trumpy@gmail.com",
+        "firstName": "Donald",
+        "lastName": "Trump",
+    }
+    participant = ParticipantModel(user=user.userId, status="created")
+
     workshop = WorkshopModel(
         name="workshop_name_1",
         startAt=datetime(2020, 1, 1, 1, 1, 1),
@@ -114,6 +131,7 @@ def setup_data(init_coach, request):
         coachId=init_coach.id,
         creatorId=init_coach.id,
         model=model,
+        participants=[participant],
     )
 
     workshop.save()
@@ -126,19 +144,20 @@ def setup_data(init_coach, request):
         action_card_batch1.delete()
         action_card_batch2.delete()
         workshop.delete()
+        user.delete()
 
     request.addfinalizer(teardown)
 
-    return workshop, model, action_cards, action_card_batches
+    return workshop, model, action_cards, action_card_batches, user, user_to_add
 
 
 def test_get_workshop(client, auth, init_coach, setup_data):
-    workshop, model, action_cards, action_card_batches = setup_data
+    workshop, model, action_cards, action_card_batches, user, user_to_add = setup_data
     headers = auth.login(email="coach@test.com")
 
     response = client.get("/api/v1/workshops/{}".format(workshop.id), headers=headers)
     response_data, status_code = json.loads(response.data), response.status_code
-
+    print(response_data)
     expected_output = {
         "name": workshop.name,
         "startAt": workshop.startAt.isoformat(),
@@ -148,6 +167,15 @@ def test_get_workshop(client, auth, init_coach, setup_data):
         "coachId": workshop.coachId,
         "creatorId": workshop.creatorId,
         "id": workshop.id,
+        "participants": [
+            {
+                "status": "created",
+                "email": user.email,
+                "firstName": user.firstName,
+                "lastName": user.lastName,
+                "userId": user.userId,
+            }
+        ],
         "model": {
             "id": model.id,
             "globalCarbonVariables": model.globalCarbonVariables,
@@ -179,3 +207,41 @@ def test_get_workshop(client, auth, init_coach, setup_data):
     }
     assert status_code == 200
     assert response_data == expected_output
+
+
+def test_add_participant_workshop(client, auth, init_coach, setup_data, request):
+    workshop, model, action_cards, action_card_batches, user, user_to_add = setup_data
+    headers = auth.login(email="coach@test.com")
+
+    response = client.post(
+        "/api/v1/workshops/{}/participants".format(workshop.workshopId),
+        headers=headers,
+        data=json.dumps(user_to_add),
+    )
+    status_code = response.status_code
+
+    workshop.reload()
+    new_user = UserModel.find_by_email(user_to_add.get("email"))
+    assert status_code == 200
+    assert len(workshop.participants) == 2
+    assert new_user is not None
+
+    def teardown():
+        new_user.delete()
+
+    request.addfinalizer(teardown)
+
+
+def test_delete_participant_workshop(client, auth, init_coach, setup_data, request):
+    workshop, model, action_cards, action_card_batches, user, user_to_add = setup_data
+    headers = auth.login(email="coach@test.com")
+
+    response = client.delete(
+        "/api/v1/workshops/{}/participants/{}".format(workshop.workshopId, user.userId),
+        headers=headers,
+    )
+    status_code = response.status_code
+
+    workshop.reload()
+    assert status_code == 200
+    assert len(workshop.participants) == 0


### PR DESCRIPTION
Changes : 
- All primary key field name switch form `entity+Id` to `id`
- All fields called `title` changed to `name`
- Adding ordering in JSON output
- `DELETE /workshops/{workshopId}/participants/{participantId}` now return None, 204 in case of success
- `POST /workshops/{workshopId}/participants` return the participant object instead of the whole workshop object